### PR TITLE
Strip padding from base64 encoded login arg param

### DIFF
--- a/virginmedia.py
+++ b/virginmedia.py
@@ -153,7 +153,7 @@ class Hub:
         resp = self._get('login',
                          retry401=0,
                          params=self._params({
-                             "arg": base64.b64encode((username + ':' + password).encode('ascii'))}))
+                             "arg": base64.b64encode((username + ':' + password).encode('ascii')).replace(b'=', b'')}))
 
         if not resp.content:
             raise LoginFailed(textwrap.dedent(


### PR DESCRIPTION
Fixes issues when the login arg param, when encoded, ends with an equals sign. (Base64 pads encoded strings such that there are always four bytes for every three source bytes.)

The equals sign is automatically urlencoded somewhere down the line to `%3D` (maybe by requests or urllib3), which would be fine if Arris's firmware could handle something as simple as standard urlencoding, but it can't...

Luckily, their base64 decoder is tolerant of encoded strings without the padding, so rather than find a way to pass the arg parameter 'raw', we can just strip the padding from the base64-encoded string and login succeeds.