### PR TITLE
Fixed setting custom hostname in Hub class

### DIFF
--- a/hub
+++ b/hub
@@ -597,7 +597,7 @@ def main():
         needs_hub = True
 
     if needs_hub:
-        with virginmedia.Hub() as hub:
+        with virginmedia.Hub(args.host) as hub:
             if args.timeout:
                 hub.http_timeout = args.timeout
             if needs_login and args.password:


### PR DESCRIPTION
My router is on 192.168.1.1. Setting this in the `HUB` environment variable or command line arg didn't work because the result is not passed to `Hub`.