### PR TITLE
Ignore 500 errors when logging out

### DIFF
--- a/virginmedia.py
+++ b/virginmedia.py
@@ -206,7 +206,11 @@ class Hub:
         """Logs out from the hub"""
         if self.is_loggedin:
             try:
-                self._get('logout', retry401=0, params=self._nonce)
+                # The logout request returns a 500 by default.
+                self._get('logout', retry401=0, retry500=0, params=self._nonce)
+            except requests.exceptions.HTTPError as e:
+                if e.response.status_code != 500:
+                    raise
             finally:
                 self._credential = None
                 self._username = None


### PR DESCRIPTION
The web UI also generates a 500 Internal Server Error when logout is clicked, and ignores it.

Fixes #15

![image](https://user-images.githubusercontent.com/521449/211170320-aa0d3b67-2bfc-4695-84c8-034117654e51.png)
